### PR TITLE
Set Python to 3.7.3 for Gibbs compatibility

### DIFF
--- a/notes/01.md
+++ b/notes/01.md
@@ -37,7 +37,7 @@ Setup Conda Environment
 ### Create Environment
 
 -   To create a new environment, type:
-    `conda create --name CS410 python=3`
+    `conda create --name CS410 python=3.7.3`
 
 -   Now we activate the new environment: `conda activate CS410`
 


### PR DESCRIPTION
Gibbs's glibc is not compatible with the latest Python 
```
python: /lib64/libc.so.6: version `GLIBC_2.15' not found (required by python)
python: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by python)
python: /lib64/libc.so.6: version `GLIBC_2.17' not found (required by python)
```